### PR TITLE
Restore TL Customizer control styling in unscoped lightbox

### DIFF
--- a/customcss.css
+++ b/customcss.css
@@ -644,3 +644,84 @@ color:rgba(0,0,0,0.5);
 
 
 
+/* === Mirror controls styling for unscoped lightbox === */
+/* Containers / layout */
+#tlc-lightbox .sliders { display:block; width:100%; margin-top:8px; }
+#tlc-lightbox .slider-container {
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  width:100%;
+  max-width:600px;
+  color:#fff;
+  text-align:center;
+}
+#tlc-lightbox .slider-container input[type="text"] { margin:4px 0 12px; }
+#tlc-lightbox .slider label { display:block; text-align:center; color:#fff; }
+#tlc-lightbox .slider input { width:100%; }
+
+/* Movement buttons */
+#tlc-lightbox .movement-button-set { display:flex; flex-direction:column; align-items:center; margin-bottom:10px; }
+#tlc-lightbox .movement-button-container { display:flex; justify-content:center; gap:12px; }
+#tlc-lightbox .movement-button-container button {
+  width:55px; height:30px; background-color:#7FBF6E;
+  border-radius:8px; border:none; cursor:pointer;
+}
+
+/* Size preset buttons */
+#tlc-lightbox .container { display:flex; flex-direction:column; align-items:center; justify-content:center !important; }
+#tlc-lightbox .size-buttons { display:flex; flex-direction:row; justify-content:center; gap:10px; margin-top:5px; }
+#tlc-lightbox .size-buttons button {
+  background-color:#7FBF6E; border:none; color:#000;
+  padding:5px 10px; border-radius:4px; font-size:16px; margin:3px 2px; cursor:pointer;
+}
+#tlc-lightbox .size-buttons button:active { background-color:#5d8c55; }
+
+/* Font dropdown */
+#tlc-lightbox .dropdown { position:relative; display:inline-block; text-align:center; margin-top:10px; }
+#tlc-lightbox .dropdown-content {
+  display:none; position:fixed; top:2.5vh; transform:translateX(-50%) !important;
+  height:95vh; overflow-y:auto; min-width:160px; z-index:1000; text-align:center;
+  background:rgba(255,0,0,0.2); /* matches existing behavior */
+}
+#tlc-lightbox .dropdown-content.show { display:block; }
+#tlc-lightbox .dropdown-content a {
+  color:#000; background:#fff; padding:10px 5px; text-decoration:none; display:block; border-bottom:1px solid #ddd;
+}
+#tlc-lightbox .dropdown-content a:last-child { border-bottom:none; }
+
+/* Toggle switch */
+#tlc-lightbox .toggle-checkbox {
+  -webkit-appearance:none; appearance:none; position:relative; display:block;
+  width:135px; height:40px; margin-bottom:6px; border-radius:17px; cursor:pointer; background:none;
+}
+#tlc-lightbox .toggle-checkbox:before,
+#tlc-lightbox .toggle-checkbox:after {
+  position:absolute; left:5px; top:5px; width:55px; height:30px;
+  border:5px solid; border-radius:12px; text-align:center; line-height:20px; font-size:12px; transition:all .3s ease-out; box-sizing:border-box;
+}
+#tlc-lightbox .toggle-checkbox:before { content:"BACK"; color:#d93816; border-color:#ff6645; background:#ffddcc; }
+#tlc-lightbox .toggle-checkbox:after  { left:auto; right:5px; content:"FRONT"; border-color:#34a84d; color:#30ba4e; background:#ccffbb; opacity:.4; }
+#tlc-lightbox .toggle-checkbox:checked:after { opacity:1; }
+#tlc-lightbox .toggle-checkbox:checked:before { opacity:.4; }
+
+/* Delete button */
+#tlc-lightbox .delete-button {
+  width:40px; background-color:#7FBF6E; border-radius:4px; border:none; color:#000;
+  font-size:20px; font-family:Arial, sans-serif; margin:10px auto; display:block; cursor:pointer;
+}
+#tlc-lightbox .delete-button:active { background-color:#5d8c55; }
+
+/* Keep wrappers visually clean (no white cards) */
+#tlc-lightbox .container,
+#tlc-lightbox .slider-container,
+#tlc-lightbox .text-container,
+#tlc-lightbox .image-container,
+#tlc-lightbox .movement-button-set,
+#tlc-lightbox .size-buttons {
+  background:transparent !important;
+  border:0 !important;
+  box-shadow:none !important;
+  padding:0 !important;
+}


### PR DESCRIPTION
## Summary
- mirror the TL Customizer control styling so the unscoped `#tlc-lightbox` markup renders with the intended buttons, sliders, and dropdowns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e426641fa88325b3b3c6fd71cd6966